### PR TITLE
fix: export MCReactModule as default for ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-export class MCReactModule {
+export default class MCReactModule {
     static isPushEnabled(): Promise<boolean>;
     static enablePush(): void;
     static disablePush(): void;


### PR DESCRIPTION
Typings are exported as named export, while the source is exported as default.