### PR TITLE
Added to dynamically fetch the android sdk version with the react-native version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,12 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def sdkVersion(){
+     def jsonFile = file('../package.json')
+     def parsedJson = new groovy.json.JsonSlurper().parseText(jsonFile.text)
+     parsedJson.version
+}
+
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
@@ -40,7 +46,7 @@ repositories {
 
 dependencies {
     api "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    api "com.salesforce.marketingcloud:marketingcloudsdk:${safeExtGet('marketingCloudVersion', '7.3.+')}"
+    api "com.salesforce.marketingcloud:marketingcloudsdk:${safeExtGet('marketingCloudVersion', sdkVersion())}"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.3'
     testImplementation 'org.mockito:mockito-core:2.28.2'


### PR DESCRIPTION
- Added to dynamically fetch the android sdk version with the react-native version

Problem: Android SDK update where the React-Native SDK is not updated together the file fetches the latest version of the Android SDK causing a problem in the react-native link and breaking the app build.