### PR TITLE
Expose setPushToken method to react-native lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Follow [these instructions](./ios_push.md) to enable push for iOS.
     * [.enablePush()](#MCReactModule.enablePush)
     * [.disablePush()](#MCReactModule.disablePush)
     * [.getSystemToken()](#MCReactModule.getSystemToken) ⇒ <code>Promise.&lt;?string&gt;</code>
+    * [.setPushToken(token)](#MCReactModule.setPushToken)
     * [.getAttributes()](#MCReactModule.getAttributes) ⇒ <code>Promise.&lt;Object.&lt;string, string&gt;&gt;</code>
     * [.setAttribute(key, value)](#MCReactModule.setAttribute)
     * [.clearAttribute(key)](#MCReactModule.clearAttribute)
@@ -181,6 +182,23 @@ the device.
 
 - [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/6.0/reference/com/salesforce/marketingcloud/messages/push/PushMessageManager.html#getPushToken())
 - [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledoc/Classes/MarketingCloudSDK.html#//api/name/sfmc_deviceToken)
+
+<a name="MCReactModule.setPushToken"></a>
+
+### MCReactModule.setPushToken(token)
+Set the Firebase or APN token used by the Marketing Cloud to send push messages to
+the device.
+
+**Kind**: static method of [<code>MCReactModule</code>](#MCReactModule)  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/7.4/com.salesforce.marketingcloud.messages.push/-push-message-manager/set-push-token.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledoc/Classes/MarketingCloudSDK.html#/c:objc(cs)MarketingCloudSDK(im)sfmc_setDeviceToken:)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| token | <code>string</code> | The Firebase or APN token to be used by Marketing Cloud |
 
 <a name="MCReactModule.getAttributes"></a>
 
@@ -326,9 +344,6 @@ Android and Xcode/Console.app for iOS).  This content can help diagnose most iss
 the SDK and will be requested by the Marketing Cloud support team.
 
 **Kind**: static method of [<code>MCReactModule</code>](#MCReactModule)  
-
-
----
 
 ### 3rd Party Product Language Disclaimers
 Where possible, we changed noninclusive terms to align with our company value of Equality. We retained noninclusive terms to document a third-party system, but we encourage the developer community to embrace more inclusive language. We can update the term when it’s no longer required for technical accuracy.

--- a/android/src/main/java/com/salesforce/marketingcloud/reactnative/RNMarketingCloudSdkModule.java
+++ b/android/src/main/java/com/salesforce/marketingcloud/reactnative/RNMarketingCloudSdkModule.java
@@ -93,6 +93,16 @@ public class RNMarketingCloudSdkModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setPushToken(final String token) {
+        handleAction(new Action() {
+            @Override
+            void execute(MarketingCloudSdk sdk) {
+                sdk.getPushMessageManager().setPushToken(token);
+            }
+        });
+    }
+
+    @ReactMethod
     public void getAttributes(Promise promise) {
         handleAction(new PromiseAction(promise) {
             @Override

--- a/android/src/test/java/com/salesforce/marketingcloud/reactnative/RNMarketingCloudSdkModuleTest.java
+++ b/android/src/test/java/com/salesforce/marketingcloud/reactnative/RNMarketingCloudSdkModuleTest.java
@@ -152,6 +152,18 @@ public class RNMarketingCloudSdkModuleTest {
     }
 
     @Test
+    public void setPushToken() {
+        // GIVEN
+        ShadowMarketingCloudSdk.isReady(true);
+
+        // WHEN
+        reactModule.setPushToken("new-token");
+
+        // THEN
+        verify(pushMessageManager).setPushToken("new-token");
+    }
+
+    @Test
     public void getAttributes() {
         // GIVEN
         ShadowMarketingCloudSdk.isReady(true);

--- a/ios/RNMarketingCloudSdk.m
+++ b/ios/RNMarketingCloudSdk.m
@@ -74,6 +74,10 @@ RCT_EXPORT_METHOD(getSystemToken
     resolve(deviceToken);
 }
 
+RCT_EXPORT_METHOD(setPushToken : (NSString *_Nonnull)token) {
+    [[MarketingCloudSDK sharedInstance] sfmc_setDeviceToken:token];
+}
+
 RCT_EXPORT_METHOD(setContactKey : (NSString *_Nonnull)contactKey) {
     [[MarketingCloudSDK sharedInstance] sfmc_setContactKey:contactKey];
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,17 @@ class MCReactModule {
     }
 
     /**
+     * Set the Firebase or APN token used by the Marketing Cloud to send push messages to
+     * the device.
+     * @param  {string} token - The Firebase or APN token to be used by Marketing Cloud
+     * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/7.4/com.salesforce.marketingcloud.messages.push/-push-message-manager/set-push-token.html|Android Docs}
+     * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledoc/Classes/MarketingCloudSDK.html#/c:objc(cs)MarketingCloudSDK(im)sfmc_setDeviceToken:|iOS Docs}
+     */
+    static setPushToken(token) {
+        RNMarketingCloudSdk.setPushToken(token);
+    }
+
+    /**
      * Returns the maps of attributes set in the registration.
      * @returns {Promise<Object.<string, string>>} A promise to the key/value map of attributes set
      *     in the registration.


### PR DESCRIPTION
In one  of my particular use-case, we refresh the token dynamically (expire and refresh token) from react native side of our app. We currently do this by having our own custom react native bridge to call respective function in native sdk. I was thinking it would be nice to have this function exposed by the library itself so others with similar use case con consume the API easily.

I also believe this adds make it easy for those using multiple push sdk in the app.

- Added java test
- Added  Android & iOS implementation of `setPushToken`
- Updated doc link to 8.0x