### PR TITLE
Add Inbox messages functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,5 +455,188 @@ Checks if Predictive Intelligence analytics is enabled in the Marketing Cloud SD
 - [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/sdk-implementation/runtime-toggles.html)
 
 
+### InboxMessaging Module
+import { SFMCInboxModule } from "react-native-marketingcloudsdk".
+
+**Kind**: global class  
+
+* [SFMCInboxModule](#SFMCInboxModule)
+    * [.deleteMessage(messageId)](#SFMCInboxModule.deleteMessage)
+    * [.getDeletedMessageCount()](#SFMCInboxModule.getDeletedMessageCount) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.getDeletedMessages()](#SFMCInboxModule.getDeletedMessages) ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+    * [.getMessages()](#SFMCInboxModule.getMessages) ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+    * [.getMessageCount()](#SFMCInboxModule.getMessageCount) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.getReadMessageCount()](#SFMCInboxModule.getReadMessageCount) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.getReadMessages()](#SFMCInboxModule.getReadMessages) ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+    * [.getUnreadMessageCount()](#SFMCInboxModule.getUnreadMessageCount) ⇒ <code>Promise.&lt;number&gt;</code>
+    * [.getUnreadMessages()](#SFMCInboxModule.getUnreadMessages) ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+    * [.markAllMessagesDeleted()](#SFMCInboxModule.markAllMessagesDeleted)
+    * [.markAllMessagesRead()](#SFMCInboxModule.markAllMessagesRead)
+    * [.refreshInbox()](#SFMCInboxModule.refreshInbox)
+    * [.setMessageRead(messageId)](#SFMCInboxModule.setMessageRead)
+
+<a name="SFMCInboxModule.deleteMessage"></a>
+
+### SFMCInboxModule.deleteMessage(messageId)
+Marks an InboxMessage as deleted in local storage. This will prevent the message from being shown in the future unless local storage is cleared on the device.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/delete-message.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markMessageWithIdDeletedWithMessageId:)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| messageId | <code>string</code> | The id of the InboxMessage to mark as deleted. |
+
+<a name="SFMCInboxModule.getDeletedMessageCount"></a>
+
+### SFMCInboxModule.getDeletedMessageCount() ⇒ <code>Promise.&lt;number&gt;</code>
+Get the number of deleted Inbox Messages regardless of their read status.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;number&gt;</code> - A numerical representation of the total number of deleted messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-deleted-message-count.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getDeletedMessagesCount)
+
+<a name="SFMCInboxModule.getDeletedMessages"></a>
+
+### SFMCInboxModule.getDeletedMessages() ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+Gets a list of Active, Deleted Inbox Messages.
+A Inbox Message is considered Active if its startDateUtc is in the past and its endDateUtc is NULL or in the future.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code> - An array of Inbox Messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-deleted-messages.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getDeletedMessages)
+
+<a name="SFMCInboxModule.getMessages"></a>
+
+### SFMCInboxModule.getMessages() ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+Gets a list of active, read, and unread Inbox Messages that are not deleted.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code> - An array of Inbox Messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-messages.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getAllMessages)
+
+<a name="SFMCInboxModule.getMessageCount"></a>
+
+### SFMCInboxModule.getMessageCount() ⇒ <code>Promise.&lt;number&gt;</code>
+Get the total number of not deleted Inbox Messages regardless of their read status.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;number&gt;</code> - a representation of the total number of messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-message-count.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getAllMessagesCount)
+
+<a name="SFMCInboxModule.getReadMessageCount"></a>
+
+### SFMCInboxModule.getReadMessageCount() ⇒ <code>Promise.&lt;number&gt;</code>
+Get the number of read, non-deleted Inbox Messages.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;number&gt;</code> - a representation of the number of read messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-read-message-count.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getReadMessagesCount)
+
+<a name="SFMCInboxModule.getReadMessages"></a>
+
+### SFMCInboxModule.getReadMessages() ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+Gets a list of active, read, not deleted Inbox Messages.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code> - an array of Inbox Messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-read-messages.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getReadMessages)
+
+<a name="SFMCInboxModule.getUnreadMessageCount"></a>
+
+### SFMCInboxModule.getUnreadMessageCount() ⇒ <code>Promise.&lt;number&gt;</code>
+Get the number of unread, non-deleted Inbox Messages.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;number&gt;</code> - a representation of the number of unread messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-unread-message-count.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getUnreadMessagesCount)
+
+<a name="SFMCInboxModule.getUnreadMessages"></a>
+
+### SFMCInboxModule.getUnreadMessages() ⇒ <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code>
+Gets a list of active, unread, non-deleted Inbox Messages.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**Returns**: <code>Promise.&lt;Array.&lt;InboxMessage&gt;&gt;</code> - an array of Inbox Messages.  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-unread-messages.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getUnreadMessages)
+
+<a name="SFMCInboxModule.markAllMessagesDeleted"></a>
+
+### SFMCInboxModule.markAllMessagesDeleted()
+Marks all active InboxMessages as deleted.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/mark-all-messages-deleted.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markAllMessagesDeleted)
+
+<a name="SFMCInboxModule.markAllMessagesRead"></a>
+
+### SFMCInboxModule.markAllMessagesRead()
+Marks all active, unread InboxMessages as read.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/mark-all-messages-read.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markAllMessagesRead)
+
+<a name="SFMCInboxModule.refreshInbox"></a>
+
+### SFMCInboxModule.refreshInbox()
+Requests an updated list of Inbox Messages from the Marketing Cloud Servers. This request can be made, at most, once per minute. This throttle also includes the Inbox request that is made by the SDK when your application is brought into the foreground.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/refresh-inbox.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)refreshMessages)
+
+<a name="SFMCInboxModule.setMessageRead"></a>
+
+### SFMCInboxModule.setMessageRead(messageId)
+Marks an InboxMessage as read in local storage. This status will persist unless local storage is cleared on the device.
+
+**Kind**: static method of [<code>SFMCInboxModule</code>](#SFMCInboxModule)  
+**See**
+
+- [Android Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/set-message-read.html)
+- [iOS Docs](https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markMessageWithIdReadWithMessageId:)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| messageId | <code>string</code> | the id of the InboxMessage to mark as read. |
+
+
 ### 3rd Party Product Language Disclaimers
 Where possible, we changed noninclusive terms to align with our company value of Equality. We retained noninclusive terms to document a third-party system, but we encourage the developer community to embrace more inclusive language. We can update the term when it’s no longer required for technical accuracy.

--- a/android/src/main/java/com/salesforce/marketingcloud/reactnative/InboxMessagingUtility.java
+++ b/android/src/main/java/com/salesforce/marketingcloud/reactnative/InboxMessagingUtility.java
@@ -25,36 +25,41 @@
  */
 package com.salesforce.marketingcloud.reactnative;
 
-import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
-import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.uimanager.ViewManager;
-import com.salesforce.marketingcloud.MCLogListener;
-import com.salesforce.marketingcloud.MarketingCloudSdk;
-import java.util.ArrayList;
-import java.util.Collections;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.salesforce.marketingcloud.messages.inbox.InboxMessage;
+
 import java.util.List;
 
-@SuppressWarnings("unused")
-public class RNSFMCSdk implements ReactPackage {
-    @Override
-    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        List<NativeModule> modules = new ArrayList<>();
+public class InboxMessagingUtility {
+    public static WritableMap mapInboxMessage(InboxMessage message) {
+        WritableMap result = Arguments.createMap();
+        result.putString("id", message.id());
+        result.putString("alert", message.alert());
+        result.putString("subject", message.subject());
+        result.putString("custom", message.custom());
+        result.putNull("name");
+        result.putString("title", message.title());
+        result.putString("url", message.url());
+        result.putBoolean("deleted", message.deleted());
+        result.putBoolean("read", message.read());
+        result.putString("sound", message.sound());
+        result.putNull("subtitle");
+        result.putDouble("startDate", message.startDateUtc().getTime());
+        result.putDouble("endDate", message.endDateUtc().getTime());
+        result.putDouble("sendDate", message.sendDateUtc().getTime());
 
-        modules.add(new RNSFMCSdkModule(reactContext));
-        modules.add(new RNSFMCInboxModule(reactContext));
-
-        return modules;
+        return result;
     }
 
-    // Deprecated from RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
+    public static WritableArray mapInboxMessages(List<InboxMessage> messages) {
+        WritableArray result = Arguments.createArray();
 
-    @Override
-    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-        return Collections.emptyList();
+        for (InboxMessage message : messages) {
+            result.pushMap(mapInboxMessage(message));
+        }
+
+        return result;
     }
 }

--- a/android/src/main/java/com/salesforce/marketingcloud/reactnative/RNSFMCInboxModule.java
+++ b/android/src/main/java/com/salesforce/marketingcloud/reactnative/RNSFMCInboxModule.java
@@ -1,0 +1,239 @@
+/*
+  Copyright 2019 Salesforce, Inc
+  <p>
+  Redistribution and use in source and binary forms, with or without modification, are permitted
+  provided that the following conditions are met:
+  <p>
+  1. Redistributions of source code must retain the above copyright notice, this list of
+  conditions and the following disclaimer.
+  <p>
+  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+  conditions and the following disclaimer in the documentation and/or other materials provided
+  with the distribution.
+  <p>
+  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+  endorse or promote products derived from this software without specific prior written permission.
+  <p>
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.marketingcloud.reactnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.salesforce.marketingcloud.messages.inbox.InboxMessage;
+import com.salesforce.marketingcloud.messages.inbox.InboxMessageManager;
+import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk;
+import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkReadyListener;
+import com.salesforce.marketingcloud.sfmcsdk.modules.push.PushModuleInterface;
+import com.salesforce.marketingcloud.sfmcsdk.modules.push.PushModuleReadyListener;
+
+import java.util.List;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class RNSFMCInboxModule extends ReactContextBaseJavaModule implements InboxMessageManager.InboxResponseListener {
+    private final ReactApplicationContext context;
+    private InboxMessageManager inboxMessageManager;
+    private int listenerCount = 0;
+
+    public RNSFMCInboxModule(ReactApplicationContext context) {
+        super(context);
+        this.context = context;
+
+        this.requestInboxMessageManager();
+    }
+
+    private void requestInboxMessageManager() {
+        SFMCSdk.requestSdk(new SFMCSdkReadyListener() {
+            @Override
+            public void ready(@NonNull SFMCSdk sfmcSdk) {
+                sfmcSdk.mp(new PushModuleReadyListener() {
+                    @Override
+                    public void ready(@NonNull PushModuleInterface pushModuleInterface) {
+                        inboxMessageManager = pushModuleInterface.getInboxMessageManager();
+                    }
+                });
+            }
+        });
+    }
+
+    private boolean isSdkNotInitialized(Promise promise) {
+        if (inboxMessageManager == null) {
+            promise.reject("SFMCSDK-INBOX",
+                    "The instance of MarketingCloudSdk is not found, MarketingCloudSdk should be initialized before the Inbox messaging usage.");
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isSdkNotInitialized() {
+        return inboxMessageManager == null;
+    }
+
+
+    @ReactMethod
+    public void deleteMessage(String id) {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.deleteMessage(id);
+    }
+
+    @ReactMethod
+    public void getDeletedMessageCount(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        int count = inboxMessageManager.getDeletedMessageCount();
+        promise.resolve(count);
+    }
+
+    @ReactMethod
+    public void getDeletedMessages(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+
+        List<InboxMessage> messages = inboxMessageManager.getDeletedMessages();
+        WritableArray result = InboxMessagingUtility.mapInboxMessages(messages);
+
+        promise.resolve(result);
+    }
+
+    @ReactMethod
+    public void getMessages(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        List<InboxMessage> messages = inboxMessageManager.getMessages();
+        WritableArray result = InboxMessagingUtility.mapInboxMessages(messages);
+
+        promise.resolve(result);
+    }
+
+    @ReactMethod
+    public void getMessageCount(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        int count = inboxMessageManager.getMessageCount();
+
+        promise.resolve(count);
+    }
+
+    @ReactMethod
+    public void getReadMessageCount(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        int count = inboxMessageManager.getReadMessageCount();
+        promise.resolve(count);
+    }
+
+    @ReactMethod
+    public void getReadMessages(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        List<InboxMessage> messages = inboxMessageManager.getReadMessages();
+        WritableArray result = InboxMessagingUtility.mapInboxMessages(messages);
+
+        promise.resolve(result);
+    }
+
+    @ReactMethod
+    public void getUnreadMessageCount(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        int count = inboxMessageManager.getUnreadMessageCount();
+        promise.resolve(count);
+    }
+
+    @ReactMethod
+    public void getUnreadMessages(Promise promise) {
+        if (isSdkNotInitialized(promise)) return;
+        List<InboxMessage> messages = inboxMessageManager.getUnreadMessages();
+        WritableArray result = InboxMessagingUtility.mapInboxMessages(messages);
+
+        promise.resolve(result);
+    }
+
+    @ReactMethod
+    public void markAllMessagesDeleted() {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.markAllMessagesDeleted();
+    }
+
+    @ReactMethod
+    public void markAllMessagesRead() {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.markAllMessagesRead();
+    }
+
+
+    @ReactMethod
+    public void refreshInbox(Promise promise) {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.refreshInbox(promise::resolve);
+    }
+
+
+    @ReactMethod
+    public void setMessageRead(String messageId) {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.setMessageRead(messageId);
+    }
+
+
+    @Override
+    public String getName() {
+        return "RNSFMCInboxModule";
+    }
+
+    private void sendEvent(ReactApplicationContext reactContext,
+                           @NonNull WritableArray params) {
+        reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit("ON_INBOX_MESSAGES_CHANGED", params);
+    }
+
+    public void onInboxMessagesChangedEvent() {
+        if (isSdkNotInitialized()) return;
+
+        List<InboxMessage> messages = inboxMessageManager.getMessages();
+        WritableArray result = InboxMessagingUtility.mapInboxMessages(messages);
+
+        sendEvent(context, result);
+    }
+
+    @Override
+    public void onInboxMessagesChanged(@NonNull List<InboxMessage> list) {
+        if (listenerCount != 0) {
+            onInboxMessagesChangedEvent();
+        }
+    }
+
+    @ReactMethod
+    public void addListener(String _eventName) {
+        if (listenerCount == 0) {
+            startObserving();
+        }
+        listenerCount += 1;
+    }
+
+    @ReactMethod
+    public void removeListeners(int count) {
+        listenerCount -= count;
+        if (listenerCount == 0) {
+            stopObserving();
+        }
+    }
+
+    private void startObserving() {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.registerInboxResponseListener(this);
+    }
+
+    private void stopObserving() {
+        if (isSdkNotInitialized()) return;
+        inboxMessageManager.unregisterInboxResponseListener(this);
+    }
+
+}

--- a/ios/InboxMessagingUtility.h
+++ b/ios/InboxMessagingUtility.h
@@ -1,0 +1,33 @@
+// InboxMessagingUtility.h
+//
+// Copyright (c) 2023 Salesforce, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer. Redistributions in binary
+// form must reproduce the above copyright notice, this list of conditions and
+// the following disclaimer in the documentation and/or other materials
+// provided with the distribution. Neither the name of the nor the names of
+// its contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+@interface InboxMessagingUtility : NSObject
+
++ (NSDictionary*)mapInboxMessage:(NSDictionary*) message;
++ (NSArray*)mapInboxMessages:(NSArray*) messages;
+
+@end

--- a/ios/InboxMessagingUtility.m
+++ b/ios/InboxMessagingUtility.m
@@ -1,0 +1,71 @@
+// InboxMessagingUtility.m
+//
+// Copyright (c) 2023 Salesforce, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer. Redistributions in binary
+// form must reproduce the above copyright notice, this list of conditions and
+// the following disclaimer in the documentation and/or other materials
+// provided with the distribution. Neither the name of the nor the names of
+// its contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import "InboxMessagingUtility.h"
+
+@implementation InboxMessagingUtility
+
++ (NSObject*)safeMap: (NSObject*) item {
+  if(item == nil) {
+    return [NSNull null];
+  }
+  
+  return item;
+}
+
++ (NSNumber*) mapTimestamp: (NSDate*) date {
+  NSTimeInterval interval = [date timeIntervalSince1970];
+  return @(interval * 1000);
+}
+
++ (NSDictionary*)mapInboxMessage: (NSDictionary*) message {
+  return @{
+    @"id": [self safeMap: message[@"id"]],
+    @"alert": [self safeMap: message[@"alert"]],
+    @"subject": [self safeMap: message[@"subject"]],
+    @"custom": [self safeMap: message[@"custom"]],
+    @"name": [self safeMap: message[@"name"]],
+    @"title": [self safeMap: message[@"title"]],
+    @"url": [self safeMap: message[@"url"]],
+    @"deleted": message[@"deleted"],
+    @"read": message[@"read"],
+    @"sound": [self safeMap: message[@"sound"]],
+    @"startDate": [self mapTimestamp: message[@"startDateUtc"]],
+    @"endDate": [self mapTimestamp: message[@"endDateUtc"]],
+    @"sendDate": [self mapTimestamp: message[@"sendDateUtc"]],
+  };
+}
+
++ (NSArray*)mapInboxMessages: (NSArray*) messages {
+  NSMutableArray *result = [NSMutableArray array];
+  for (NSDictionary *message in messages) {
+    [result addObject: [InboxMessagingUtility mapInboxMessage:message]];
+  }
+  return result;
+}
+
+@end

--- a/ios/RNSFMCInboxModule.h
+++ b/ios/RNSFMCInboxModule.h
@@ -1,0 +1,38 @@
+// RNSFMCInboxModule.h
+//
+// Copyright (c) 2023 Salesforce, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer. Redistributions in binary
+// form must reproduce the above copyright notice, this list of conditions and
+// the following disclaimer in the documentation and/or other materials
+// provided with the distribution. Neither the name of the nor the names of
+// its contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+#if __has_include("RCTBridgeModule.h")
+#import "RCTBridgeModule.h"
+#else
+#import <React/RCTBridgeModule.h>
+#endif
+#import <React/RCTEventEmitter.h>
+
+@interface RNSFMCInboxModule : RCTEventEmitter <RCTBridgeModule>
+
+@end

--- a/ios/RNSFMCInboxModule.m
+++ b/ios/RNSFMCInboxModule.m
@@ -1,0 +1,199 @@
+// RNSFMCInboxModule.m
+//
+// Copyright (c) 2023 Salesforce, Inc
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer. Redistributions in binary
+// form must reproduce the above copyright notice, this list of conditions and
+// the following disclaimer in the documentation and/or other materials
+// provided with the distribution. Neither the name of the nor the names of
+// its contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+
+#import "RNSFMCInboxModule.h"
+#import <SFMCSDK/SFMCSDK.h>
+#import <MarketingCloudSDK/MarketingCloudSDK.h>
+#import "InboxMessagingUtility.h"
+
+@implementation RNSFMCInboxModule
+
+- (BOOL)isSdkNotInitialized: (RCTPromiseRejectBlock)reject {
+    if ([[SFMCSdk mp] getStatus] != SFMCSdkModuleStatusOperational) {
+        reject(@"SFMC_SDK_ERROR", @"IS_NOT_INITIALIZED", nil);
+        return true;
+    }
+    return false;
+}
+
+- (BOOL)isSdkNotInitialized {
+    if ([[SFMCSdk mp] getStatus] != SFMCSdkModuleStatusOperational) {
+        return true;
+    }
+    return false;
+}
+
+RCT_EXPORT_METHOD(deleteMessage:(NSString*)messageId)
+{
+    if([self isSdkNotInitialized]) return;
+    BOOL _result = [[SFMCSdk mp] markMessageWithIdDeletedWithMessageId:messageId];
+}
+
+RCT_EXPORT_METHOD(getDeletedMessageCount:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    BOOL result = [[SFMCSdk mp] getDeletedMessagesCount];
+    resolve(@(result));
+}
+
+RCT_EXPORT_METHOD(getDeletedMessages: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    NSArray* messages = [[SFMCSdk mp] getDeletedMessages];
+    NSArray* result = [InboxMessagingUtility mapInboxMessages:messages];
+    
+    resolve(result);
+}
+
+
+RCT_EXPORT_METHOD(getMessages: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    NSArray* messages = [[SFMCSdk mp] getAllMessages];
+    NSArray* result = [InboxMessagingUtility mapInboxMessages:messages];
+    
+    resolve(result);
+}
+
+
+RCT_EXPORT_METHOD(getMessageCount: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    long count = [[SFMCSdk mp] getAllMessagesCount];
+    resolve(@(count));
+}
+
+RCT_EXPORT_METHOD(getReadMessageCount: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    long count = [[SFMCSdk mp] getReadMessagesCount];
+    resolve(@(count));
+}
+
+RCT_EXPORT_METHOD(getReadMessages: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    NSArray* messages = [[SFMCSdk mp] getReadMessages];
+    NSArray* result = [InboxMessagingUtility mapInboxMessages:messages];
+    
+    resolve(result);
+}
+
+RCT_EXPORT_METHOD(getUnreadMessageCount: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    long count = [[SFMCSdk mp] getUnreadMessagesCount];
+    resolve(@(count));
+}
+
+RCT_EXPORT_METHOD(getUnreadMessages: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    NSArray* messages = [[SFMCSdk mp] getUnreadMessages];
+    NSArray* result = [InboxMessagingUtility mapInboxMessages:messages];
+    
+    resolve(result);
+}
+
+RCT_EXPORT_METHOD(markAllMessagesDeleted: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    BOOL result = [[SFMCSdk mp] markAllMessagesDeleted];
+    resolve(@(result));
+}
+
+RCT_EXPORT_METHOD(markAllMessagesRead: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    BOOL result = [[SFMCSdk mp] markAllMessagesRead];
+    resolve(@(result));
+}
+
+RCT_EXPORT_METHOD(refreshInbox: (RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    BOOL result = [[SFMCSdk mp] refreshMessages];
+    resolve(@(result));
+}
+
+RCT_EXPORT_METHOD(setMessageRead:(NSString*)messageId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if([self isSdkNotInitialized: reject]) return;
+    BOOL result = [[SFMCSdk mp] markMessageWithIdReadWithMessageId:messageId];
+    resolve(@(result));
+}
+
+-(void)startObserving {
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(onRefresh:)
+     name: SFMCInboxMessagesRefreshCompleteNotification
+     object:nil];
+}
+
+-(void)stopObserving {
+    [[NSNotificationCenter defaultCenter]
+     removeObserver:self
+     name:SFMCInboxMessagesRefreshCompleteNotification
+     object:nil];
+}
+
+
+- (NSArray<NSString *> *)supportedEvents
+{
+    return @[@"onInboxMessagesChanged"];
+}
+
+- (void)onRefresh:(NSNotification *)notification {
+    NSArray* messages = [[SFMCSdk mp] getAllMessages];
+    NSArray* result = [InboxMessagingUtility mapInboxMessages:messages];
+    
+    [self sendEventWithName: @"onInboxMessagesChanged" body:result];
+}
+
+
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
+RCT_EXPORT_MODULE()
+
+@end

--- a/ios/RNSFMCSdk.xcodeproj/project.pbxproj
+++ b/ios/RNSFMCSdk.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		497C2BF02BDF9E9900CA14F8 /* InboxMessagingUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 497C2BEC2BDF9E9900CA14F8 /* InboxMessagingUtility.m */; };
+		497C2BF12BDF9E9900CA14F8 /* RNSFMCInboxModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 497C2BEF2BDF9E9900CA14F8 /* RNSFMCInboxModule.m */; };
 		C3DE97D629DED9420023BE4C /* RNSFMCSdk.m in Sources */ = {isa = PBXBuildFile; fileRef = C3DE97D529DED9420023BE4C /* RNSFMCSdk.m */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +26,10 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNSFMCSdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNSFMCSdk.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		497C2BEC2BDF9E9900CA14F8 /* InboxMessagingUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InboxMessagingUtility.m; sourceTree = "<group>"; };
+		497C2BED2BDF9E9900CA14F8 /* InboxMessagingUtility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InboxMessagingUtility.h; sourceTree = "<group>"; };
+		497C2BEE2BDF9E9900CA14F8 /* RNSFMCInboxModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSFMCInboxModule.h; sourceTree = "<group>"; };
+		497C2BEF2BDF9E9900CA14F8 /* RNSFMCInboxModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSFMCInboxModule.m; sourceTree = "<group>"; };
 		C3DE97D429DED9420023BE4C /* RNSFMCSdk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSFMCSdk.h; sourceTree = "<group>"; };
 		C3DE97D529DED9420023BE4C /* RNSFMCSdk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSFMCSdk.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -52,6 +58,10 @@
 			children = (
 				C3DE97D429DED9420023BE4C /* RNSFMCSdk.h */,
 				C3DE97D529DED9420023BE4C /* RNSFMCSdk.m */,
+				497C2BED2BDF9E9900CA14F8 /* InboxMessagingUtility.h */,
+				497C2BEC2BDF9E9900CA14F8 /* InboxMessagingUtility.m */,
+				497C2BEE2BDF9E9900CA14F8 /* RNSFMCInboxModule.h */,
+				497C2BEF2BDF9E9900CA14F8 /* RNSFMCInboxModule.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -113,7 +123,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				497C2BF02BDF9E9900CA14F8 /* InboxMessagingUtility.m in Sources */,
 				C3DE97D629DED9420023BE4C /* RNSFMCSdk.m in Sources */,
+				497C2BF12BDF9E9900CA14F8 /* RNSFMCInboxModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/jsdoc2md/TEMPLATE.md
+++ b/jsdoc2md/TEMPLATE.md
@@ -153,5 +153,12 @@ Follow [these instructions](./ios_push.md) to enable push for iOS.
 {{>members~}}
 {{/class}}
 
+### InboxMessaging Module
+{{#class name="SFMCInboxModule"}}
+{{>body~}}
+{{>member-index~}}
+{{>members~}}
+{{/class}}
+
 ### 3rd Party Product Language Disclaimers
 Where possible, we changed noninclusive terms to align with our company value of Equality. We retained noninclusive terms to document a third-party system, but we encourage the developer community to embrace more inclusive language. We can update the term when it’s no longer required for technical accuracy.

--- a/lib/inbox.js
+++ b/lib/inbox.js
@@ -1,0 +1,154 @@
+import { NativeModules, NativeEventEmitter } from "react-native";
+
+const { RNSFMCInboxModule } = NativeModules;
+
+/**
+ * @class SFMCInboxModule
+ * @classdesc import { SFMCInboxModule } from "react-native-marketingcloudsdk".
+ */
+export class SFMCInboxModule {
+  /**
+   * Marks an InboxMessage as deleted in local storage. This will prevent the message from being shown in the future unless local storage is cleared on the device.
+   * @param  {string} messageId - The id of the InboxMessage to mark as deleted.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/delete-message.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markMessageWithIdDeletedWithMessageId:|iOS Docs}
+   */
+  static deleteMessage(messageId) {
+    return RNSFMCInboxModule.deleteMessage(messageId);
+  }
+
+  /**
+   * Get the number of deleted Inbox Messages regardless of their read status.
+   * @returns {Promise<number>} A numerical representation of the total number of deleted messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-deleted-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getDeletedMessagesCount|iOS Docs}
+   */
+  static getDeletedMessageCount() {
+    return RNSFMCInboxModule.getDeletedMessageCount();
+  }
+
+  /**
+   * Gets a list of Active, Deleted Inbox Messages.
+   * A Inbox Message is considered Active if its startDateUtc is in the past and its endDateUtc is NULL or in the future.
+   * @returns {Promise<InboxMessage[]>} An array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-deleted-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getDeletedMessages|iOS Docs}
+   */
+  static getDeletedMessages() {
+    return RNSFMCInboxModule.getDeletedMessages();
+  }
+
+  /**
+   * Gets a list of active, read, and unread Inbox Messages that are not deleted.
+   * @returns {Promise<InboxMessage[]>} An array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getAllMessages|iOS Docs}
+   */
+  static getMessages() {
+    return RNSFMCInboxModule.getMessages();
+  }
+
+  /**
+   * Get the total number of not deleted Inbox Messages regardless of their read status.
+   * @returns {Promise<number>} a representation of the total number of messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getAllMessagesCount|iOS Docs}
+   */
+  static getMessageCount() {
+    return RNSFMCInboxModule.getMessageCount();
+  }
+
+  /**
+   * Get the number of read, non-deleted Inbox Messages.
+   * @returns {Promise<number>} a representation of the number of read messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-read-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getReadMessagesCount|iOS Docs}
+   */
+  static getReadMessageCount() {
+    return RNSFMCInboxModule.getReadMessageCount();
+  }
+
+  /**
+   * Gets a list of active, read, not deleted Inbox Messages.
+   * @returns {Promise<InboxMessage[]>} an array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-read-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getReadMessages|iOS Docs}
+   */
+  static getReadMessages() {
+    return RNSFMCInboxModule.getReadMessages();
+  }
+
+  /**
+   * Get the number of unread, non-deleted Inbox Messages.
+   * @returns {Promise<number>} a representation of the number of unread messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-unread-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getUnreadMessagesCount|iOS Docs}
+   */
+  static getUnreadMessageCount() {
+    return RNSFMCInboxModule.getUnreadMessageCount();
+  }
+
+  /**
+   * Gets a list of active, unread, non-deleted Inbox Messages.
+   * @returns {Promise<InboxMessage[]>} an array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-unread-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getUnreadMessages|iOS Docs}
+   */
+  static getUnreadMessages() {
+    return RNSFMCInboxModule.getUnreadMessages();
+  }
+
+  /**
+   * Marks all active InboxMessages as deleted.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/mark-all-messages-deleted.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markAllMessagesDeleted|iOS Docs}
+   */
+  static markAllMessagesDeleted() {
+    return RNSFMCInboxModule.markAllMessagesDeleted();
+  }
+
+  /**
+   * Marks all active, unread InboxMessages as read.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/mark-all-messages-read.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markAllMessagesRead|iOS Docs}
+   */
+  static markAllMessagesRead() {
+    return RNSFMCInboxModule.markAllMessagesRead();
+  }
+
+  /**
+   * Requests an updated list of Inbox Messages from the Marketing Cloud Servers. This request can be made, at most, once per minute. This throttle also includes the Inbox request that is made by the SDK when your application is brought into the foreground.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/refresh-inbox.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)refreshMessages|iOS Docs}
+   */
+  static refreshInbox() {
+    return RNSFMCInboxModule.refreshInbox();
+  }
+
+  /**
+   * Marks an InboxMessage as read in local storage. This status will persist unless local storage is cleared on the device.
+   * @param  {string} messageId - the id of the InboxMessage to mark as read.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/set-message-read.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markMessageWithIdReadWithMessageId:|iOS Docs}
+   */
+  static setMessageRead(messageId) {
+    return RNSFMCInboxModule.setMessageRead(messageId);
+  }
+
+  /**
+   * This method is called upon the completed of the Inbox Message refresh attempt.
+   * @callback  refreshCallback - callback function invoked after Inbox Messages refresh.
+   * @param  {messages} messages - array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/-inbox-refresh-listener/index.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Constants.html#/c:@SFMCInboxMessagesRefreshCompleteNotification|iOS Docs}
+   */
+  static inboxListener(callback) {
+    const eventEmitter = new NativeEventEmitter(RNSFMCInboxModule)
+    const eventListener = eventEmitter.addListener(
+      'onInboxMessagesChanged',
+      callback
+    )
+
+    return () => eventListener.remove();
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,3 +229,4 @@ class MCReactModule {
 export default MCReactModule;
 
 export * from "./event.js";
+export * from './inbox.js';

--- a/types/inbox.d.ts
+++ b/types/inbox.d.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2019 Salesforce, Inc
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * @class SFMCInboxModule
+ */
+
+export interface InboxMessage {
+  id: string
+  alert: string
+  subject: string
+  custom: string
+  name: string | null
+  title: string
+  url: string
+  deleted: boolean
+  read: boolean
+  sound: string
+  subtitle: string | null
+  startDate: number
+  endDate: number
+  sendDate: number
+}
+
+export class SFMCInboxModule {
+  /**
+   * Marks an InboxMessage as deleted in local storage. This will prevent the message from being shown in the future unless local storage is cleared on the device.
+   * @param  {string} messageId - The id of the InboxMessage to mark as deleted.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/delete-message.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markMessageWithIdDeletedWithMessageId:|iOS Docs}
+   */
+  static deleteMessage(messageId: string): Promise<void>;
+  /**
+   * Get the number of deleted Inbox Messages regardless of their read status.
+   * @returns {Promise<number>} A numerical representation of the total number of deleted messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-deleted-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getDeletedMessagesCount|iOS Docs}
+   */
+  static getDeletedMessageCount(): Promise<number>;
+  /**
+   * Gets a list of Active, Deleted Inbox Messages.
+   * A Inbox Message is considered Active if its startDateUtc is in the past and its endDateUtc is NULL or in the future.
+   * @returns {Promise<InboxMessage[]>} An array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-deleted-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getDeletedMessages|iOS Docs}
+   */
+  static getDeletedMessages(): Promise<InboxMessage[]>;
+  /**
+   * Gets a list of active, read, and unread Inbox Messages that are not deleted.
+   * @returns {Promise<InboxMessage[]>} An array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getAllMessages|iOS Docs}
+   */
+  static getMessages(): Promise<InboxMessage[]>;
+  /**
+   * Get the total number of not deleted Inbox Messages regardless of their read status.
+   * @returns {Promise<number>} a representation of the total number of messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getAllMessagesCount|iOS Docs}
+   */
+  static getMessageCount(): Promise<number>;
+  /**
+   * Get the number of read, non-deleted Inbox Messages.
+   * @returns {Promise<number>} a representation of the number of read messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-read-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getReadMessagesCount|iOS Docs}
+   */
+  static getReadMessageCount(): Promise<number>;
+  /**
+   * Gets a list of active, read, not deleted Inbox Messages.
+   * @returns {Promise<InboxMessage[]>} an array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-read-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getReadMessages|iOS Docs}
+   */
+  static getReadMessages(): Promise<InboxMessage[]>;
+  /**
+   * Get the number of unread, non-deleted Inbox Messages.
+   * @returns {Promise<number>} a representation of the number of unread messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-unread-message-count.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getUnreadMessagesCount|iOS Docs}
+   */
+  static getUnreadMessageCount(): Promise<number>;
+  /**
+   * Gets a list of active, unread, non-deleted Inbox Messages.
+   * @returns {Promise<InboxMessage[]>} an array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/get-unread-messages.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)getUnreadMessages|iOS Docs}
+   */
+  static getUnreadMessages(): Promise<InboxMessage[]>;
+  /**
+   * Marks all active InboxMessages as deleted.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/mark-all-messages-deleted.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markAllMessagesDeleted|iOS Docs}
+   */
+  static markAllMessagesDeleted(): Promise<void>;
+  /**
+   * Marks all active, unread InboxMessages as read.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/mark-all-messages-read.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markAllMessagesRead|iOS Docs}
+   */
+  static markAllMessagesRead(): Promise<void>;
+  /**
+   * Requests an updated list of Inbox Messages from the Marketing Cloud Servers. This request can be made, at most, once per minute. This throttle also includes the Inbox request that is made by the SDK when your application is brought into the foreground.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/refresh-inbox.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)refreshMessages|iOS Docs}
+   */
+  static refreshInbox(): Promise<boolean>;
+  /**
+   * Marks an InboxMessage as read in local storage. This status will persist unless local storage is cleared on the device.
+   * @param  {string} messageId - the id of the InboxMessage to mark as read.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/set-message-read.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Classes/PushModule.html#/c:@M@MarketingCloudSDK@objc(cs)SFMCSdkPushModule(im)markMessageWithIdReadWithMessageId:|iOS Docs}
+   */
+  static setMessageRead(id: string): Promise<void>;
+  /**
+   * This method is called upon the completed of the Inbox Message refresh attempt.
+   * @callback  refreshCallback - callback function invoked after Inbox Messages refresh.
+   * @param  {messages} messages - array of Inbox Messages.
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/javadocs/MarketingCloudSdk/8.0/com.salesforce.marketingcloud.messages.inbox/-inbox-message-manager/-inbox-refresh-listener/index.html|Android Docs}
+   * @see  {@link https://salesforce-marketingcloud.github.io/MarketingCloudSDK-iOS/appledocs/MarketingCloudSdk/8.0/Constants.html#/c:@SFMCInboxMessagesRefreshCompleteNotification|iOS Docs}
+   */
+  static inboxListener(callback: (messages: InboxMessage[]) => void): void;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -194,3 +194,4 @@ declare class MCReactModule {
 }
 
 export * from "./event";
+export * from './inbox';


### PR DESCRIPTION
Hello @billmote and salesforce marketingcloud team,

This is for a PR adding a bridge for the MarketingCloud inbox messages functionality.

Currently, [react-native-marketingcloudsdk](https://github.com/salesforce-marketingcloud/react-native-marketingcloudsdk) does not provide a bridge for the inbox messages functionality described in the native SDKs, which makes it limited in comparison with native solutions.