### PR TITLE
Add missing identity event types

### DIFF
--- a/ios/RCTConvert+SFMCEvent.m
+++ b/ios/RCTConvert+SFMCEvent.m
@@ -148,6 +148,8 @@
     NSDictionary *SFMCSdkEventType =  @{
         @"engagement": [SFMCSdkCustomEvent class],
         @"system": [SFMCSdkSystemEvent class],
+        @"identity": [SFMCSdkIdentityEvent class]
+
     };
     NSString *eventName = [RCTConvert NSString:json[@"category"]];
     return SFMCSdkEventType[eventName];


### PR DESCRIPTION
You could not use the enum of events of category of type “Identity” because they were not mapping in the function, but if it exists in the SDK and JS exposes it, if it is occupied it generates a crash in the app when using.